### PR TITLE
Added check for mismatched benchmark tests

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -58,7 +58,6 @@ function convertToMarkdown(ctx_sha, results, prettyName) {
         -------------
         new      1.00        2.1±0.02s  15.3 KElem/sec
         base     1.03        2.1±0.02s  14.9 KElem/sec
-// const utils = require("../utils");
 
         fib/200/run
         -----------
@@ -68,6 +67,16 @@ function convertToMarkdown(ctx_sha, results, prettyName) {
 
     let resultLines = results.trimRight().split("\n");
     let lines = resultLines.filter(line => !line.startsWith("--") && line != "");
+
+    if (!(lines[1].startsWith("changes") && lines[2].startsWith("base"))) {
+        return `## Benchmark for ${prettyName}
+        <details open>
+          <summary>Click to hide benchmark</summary>
+          Benchmarks have changed between the two branches, unable to diff.
+        </details>
+        `;
+    }
+
     let benchResults = chunks(lines, 3).map(([name, changes, base]) => {
         let [_baseName, baseFactor, baseDuration, baseBandwidth] = splitResultsLine(base);
         let [_changesName, changesFactor, changesDuration, changesBandwidth] = splitResultsLine(changes);

--- a/utils.test.js
+++ b/utils.test.js
@@ -30,3 +30,62 @@ base        1.66     502.4±5.30ms  63.6 KElem/sec`;
     expect(markdown.includes("| fib/200/run | 502.4±5.30ms | **301.9±6.16ms** | **-39.91%** |")).toBe(true);
 });
 
+
+test('critcmp multi-test data', () => {
+    const input_data = `
+fib/100/execute
+---------------
+changes     1.00     685.3±1.10ms  2.5 KElem/sec
+
+fib/100/proof
+-------------
+base     1.00        3.9±0.05s  16.4 KElem/sec
+
+fib/100/prove
+-------------
+changes     1.00        3.2±0.06s  19.8 KElem/sec
+
+fib/100/run
+-----------
+base     1.00     691.3±1.04ms  92.6 KElem/sec
+
+fib/100/total
+-------------
+changes     1.00        3.9±0.07s  458 Elem/sec
+
+fib/1000/execute
+----------------
+changes     1.00     692.8±2.55ms  15.2 KElem/sec
+
+fib/1000/prove
+--------------
+changes     1.00        3.2±0.06s  19.8 KElem/sec
+
+fib/1000/total
+--------------
+changes     1.00        3.9±0.07s  2.7 KElem/sec
+
+fib/10000/execute
+-----------------
+changes     1.00     752.3±1.77ms  130.8 KElem/sec
+
+fib/10000/prove
+---------------
+changes     1.00       13.2±0.12s  19.3 KElem/sec
+
+fib/10000/total
+---------------
+changes     1.00       14.0±0.11s  7.0 KElem/sec
+
+fib/200/proof
+-------------
+base     1.00        3.9±0.07s  16.3 KElem/sec
+
+fib/200/run
+-----------
+base     1.00     694.2±1.47ms  92.2 KElem/sec`;
+
+    let markdown = utils.convertToMarkdown("fc27559ad8d5f4a35712256ca38b94b394249d6d", input_data, "test");
+    expect(markdown.includes("Benchmark for test")).toBe(true);
+    expect(markdown.includes("Benchmarks have changed between the two branches, unable to diff")).toBe(true);
+});


### PR DESCRIPTION
Check for unmatched benchmarks, for example when the benchmarks themselves change between branches and report a warning back in the PR comment.